### PR TITLE
Add the ability to select custom data directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,23 @@
 import os
-
-import os
 import sys
+
+def get_settings_path():
+    """Return the path to settings.json, using AppData on Windows."""
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            app_dir = os.path.join(appdata, "DungeonMasterTool")
+            if not os.path.exists(app_dir):
+                os.makedirs(app_dir)
+            return os.path.join(app_dir, "settings.json")
+    elif sys.platform.startswith("linux"):
+        xdg_config = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        app_dir = os.path.join(xdg_config, "DungeonMasterTool")
+        if not os.path.exists(app_dir):
+            os.makedirs(app_dir)
+        return os.path.join(app_dir, "settings.json")
+    # Fallback: use cache/settings.json in project or data dir
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "cache", "settings.json")
 
 def get_base_path():
     """ PyInstaller ile uyumlu base path döner. """
@@ -13,19 +29,41 @@ BASE_DIR = get_base_path()
 
 BASE_DIR = get_base_path()
 
+
+# --- DATA ROOT SELECTION ---
+import json
 def get_data_root():
-    """ 
-    Verilerin saklanacağı dizin.
-    User isteği: 'exe dosyasının bir üst dizininde tutsun'
-    """
+    # Try to read user setting from settings.json (now in AppData on Windows/Linux)
+    import json
+    settings_path = get_settings_path()
+    try:
+        if os.path.exists(settings_path):
+            with open(settings_path, "r", encoding="utf-8") as f:
+                settings = json.load(f)
+                data_dir = settings.get("data_dir")
+                if data_dir and os.path.isdir(data_dir):
+                    return data_dir
+    except Exception:
+        pass
+    # Default: use AppData (Windows) or ~/.config (Linux)
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            app_dir = os.path.join(appdata, "DungeonMasterTool")
+            if not os.path.exists(app_dir):
+                os.makedirs(app_dir)
+            return app_dir
+    elif sys.platform.startswith("linux"):
+        xdg_config = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        app_dir = os.path.join(xdg_config, "DungeonMasterTool")
+        if not os.path.exists(app_dir):
+            os.makedirs(app_dir)
+        return app_dir
+    # Fallback: use exe's parent or project root
     if getattr(sys, 'frozen', False):
-        # Frozen (EXE): sys.executable -> .../dist/Game.exe
-        # dirname -> .../dist
-        # dirname(dirname) -> .../ (Proje kökü veya exe'nin üst klasörü)
         exe_path = sys.executable
         return os.path.dirname(os.path.dirname(exe_path))
     else:
-        # Dev: .../root/config.py -> .../root
         return os.path.dirname(os.path.abspath(__file__))
 
 DATA_ROOT = get_data_root()

--- a/ui/campaign_selector.py
+++ b/ui/campaign_selector.py
@@ -49,6 +49,22 @@ class CampaignSelector(QDialog):
         self.btn_load.setObjectName("loadBtn")
         self.btn_load.clicked.connect(self.load_campaign)
         layout.addWidget(self.btn_load)
+
+        # Data directory
+        dir_layout = QHBoxLayout()
+        self.lbl_data_dir = QLabel("Data Directory:")
+        self.inp_data_dir = QLineEdit()
+        self.inp_data_dir.setReadOnly(True)
+        self.btn_browse_dir = QPushButton("Browse")
+        self.btn_browse_dir.clicked.connect(self.browse_data_dir)
+        dir_layout.addWidget(self.lbl_data_dir)
+        dir_layout.addWidget(self.inp_data_dir)
+        dir_layout.addWidget(self.btn_browse_dir)
+        layout.addLayout(dir_layout)
+
+        # Set initial data dir to actual storage location from config
+        from config import get_data_root
+        self.inp_data_dir.setText(get_data_root())
         
         layout.addSpacing(20)
         
@@ -136,3 +152,18 @@ class CampaignSelector(QDialog):
             self.accept()
         else:
             QMessageBox.critical(self, "Hata", msg)
+
+    def browse_data_dir(self):
+        from PyQt6.QtWidgets import QFileDialog
+        dir_path = QFileDialog.getExistingDirectory(self, "Select Data Directory", self.inp_data_dir.text())
+        if dir_path:
+            self.dm.save_settings({"data_dir": dir_path})
+            # Re-instantiate DataManager and reload config so all paths update
+            import importlib
+            import config
+            importlib.reload(config)
+            from core.data_manager import DataManager
+            self.dm = DataManager()
+            from config import get_data_root
+            self.inp_data_dir.setText(get_data_root())
+            self.refresh_list()


### PR DESCRIPTION
Adds ability to select a custom data directory and manage settings across platforms, including UI components for displaying and browsing the data directory.

This will default to `%appdata%` on windows and `XDG_CONFIG_HOME` on linux based systems. The `settings.json` will always reside in the `appdata/XDG_CONFIG_HOME` location so that we can store the recently configured data location, if you would change computer or something the default storage location simply default back and you will just have to change it's location in the startup GUI.

---

### Changes
- Added `get_settings_path` to determine `settings.json` location based on OS.
- Added `get_data_root` to read and default the data directory, supporting user overrides via settings.
- Updated `DataManager` to reload path constants (`WORLDS_DIR`, `CACHE_DIR`, etc.) when `data_dir` changes.
- Enhanced `load_settings` and `save_settings` to ensure `data_dir` is always present and paths are updated on change.
- Modified `CampaignSelector` UI to display the current data directory and allow users to browse and select a new directory.
- Dynamic reloading of configuration and `DataManager` instance after directory selection.
- Modified files: `config.py`, `core/data_manager.py`, `ui/campaign_selector.py`.

### Impact
- The application now respects user-selected data directories and updates all relevant paths at runtime.
- Settings and data are stored in OS-appropriate locations by default, improving portability
- Changes may affect file location expectations for existing users and any component depending on static paths.
- No explicit breaking changes, but side effects possible if other modules cache old paths.
- UI now exposes data directory management, requiring verification of end-to-end data migration and access.


### Example 
![python_Kw1gWkKB4f](https://github.com/user-attachments/assets/b727342a-f068-4b1f-9e37-1195e5d695a9)
