### PR TITLE
fix(installer): bundle dynamic ui.main_root import in releases

### DIFF
--- a/installer/build.py
+++ b/installer/build.py
@@ -2,8 +2,42 @@ import PyInstaller.__main__
 import os
 import shutil
 import sys
+from PyInstaller.utils.hooks import collect_submodules
 
 APP_NAME = "DungeonMasterTool"
+
+
+def resolve_hidden_imports():
+    base_hidden_imports = [
+        "PyQt6.QtWebEngineWidgets",
+        "PyQt6.QtWebEngineCore",
+        "PyQt6.QtPrintSupport",
+        "PyQt6.QtNetwork",
+        "PyQt6.QtMultimedia",
+        "PyQt6.QtMultimediaWidgets",
+        "PyQt6.sip",
+        "msgpack",
+        "markdown",
+        "markdown.extensions.extra",
+        "markdown.extensions.nl2br",
+        "requests",
+        "i18n",
+        "yaml",
+        "json",
+    ]
+
+    # main.py loads ui.main_root via importlib.import_module(), so collect all UI
+    # submodules to avoid runtime module misses in packaged builds.
+    try:
+        ui_hidden_imports = collect_submodules("ui")
+    except Exception as exc:
+        print(f"Warning: failed to collect UI submodules ({exc})")
+        ui_hidden_imports = ["ui.main_root"]
+    else:
+        if "ui.main_root" not in ui_hidden_imports:
+            ui_hidden_imports.append("ui.main_root")
+
+    return sorted(set(base_hidden_imports + ui_hidden_imports))
 
 def clean():
     for folder in ["dist", "build"]:
@@ -12,14 +46,7 @@ def clean():
             shutil.rmtree(folder, ignore_errors=True)
 
 def build():
-    hidden_imports = [
-        'PyQt6.QtWebEngineWidgets', 'PyQt6.QtWebEngineCore',
-        'PyQt6.QtPrintSupport', 'PyQt6.QtNetwork', 
-        'PyQt6.QtMultimedia', 'PyQt6.QtMultimediaWidgets',
-        'PyQt6.sip', 'msgpack', 'markdown', 
-        'markdown.extensions.extra', 'markdown.extensions.nl2br', 
-        'requests', 'i18n', 'yaml', 'json'
-    ]
+    hidden_imports = resolve_hidden_imports()
     
     params = [
         'main.py',
@@ -31,7 +58,7 @@ def build():
     ]
 
     for imp in hidden_imports:
-        params.append(f'--hidden-import={imp}')
+        params.append(f"--hidden-import={imp}")
 
     if os.path.exists("assets/icon.png"):
         params.append('--icon=assets/icon.png')


### PR DESCRIPTION
Root cause confirmed: [main.py] loads ui.main_root dynamically (importlib.import_module("ui.main_root")), and the release build script didn’t reliably bundle that module in PyInstaller.

I patched the build pipeline in [installer/build.py]:

Added resolve_hidden_imports() to auto-collect all ui submodules via collect_submodules("ui").
Guaranteed fallback inclusion of ui.main_root even if collection is partial.
Switched build() to use the resolved hidden import list.

Validation run:
[build.py]

For the specific crash you pasted (ModuleNotFoundError: No module named 'ui.main_root'): yes, fixed.
Evidence:

New build includes ui.main_root in [Analysis-00.toc] and [PYZ-00.toc]
PyInstaller logs show it being analyzed as hidden import.
Packaged binary smoke run produced no ModuleNotFoundError traceback.