### PR TITLE
docs: add Patreon and thanks.dev sponsor badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@
     <img src="https://img.shields.io/badge/Download-iOS-999999?style=for-the-badge&logo=apple" alt="Download iOS" />
   </a>
   <br><br>
+  <a href="https://www.patreon.com/elymsyr">
+    <img src="https://img.shields.io/badge/Support-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white" alt="Support on Patreon" />
+  </a>
+  <a href="https://thanks.dev/u/gh/elymsyr">
+    <img src="https://img.shields.io/badge/Sponsor-thanks.dev-2EBC4F?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sponsor via thanks.dev" />
+  </a>
+  <br><br>
   <img src="https://img.shields.io/badge/Status-Beta-blue" />
   <img src="https://img.shields.io/badge/Version-v9.1.0--beta-blueviolet" />
   <img src="https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey" />
   <img src="https://img.shields.io/badge/Flutter-3.41-02569B?logo=flutter" />
   <img src="https://img.shields.io/badge/Dart-3.11-0175C2?logo=dart" />
-  <br><br>
-  <a href="https://www.patreon.com/elymsyr">
-    <img src="https://img.shields.io/badge/Patreon-Support-F96854?logo=patreon&logoColor=white" alt="Support on Patreon" />
-  </a>
-  <a href="https://thanks.dev/u/gh/elymsyr">
-    <img src="https://img.shields.io/badge/thanks.dev-Sponsor-2EBC4F" alt="Sponsor via thanks.dev" />
-  </a>
   <br>
   <b>Platforms:</b> Android | iOS | Windows | Linux | macOS
   <br>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@
   <img src="https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey" />
   <img src="https://img.shields.io/badge/Flutter-3.41-02569B?logo=flutter" />
   <img src="https://img.shields.io/badge/Dart-3.11-0175C2?logo=dart" />
+  <br><br>
+  <a href="https://www.patreon.com/elymsyr">
+    <img src="https://img.shields.io/badge/Patreon-Support-F96854?logo=patreon&logoColor=white" alt="Support on Patreon" />
+  </a>
+  <a href="https://thanks.dev/u/gh/elymsyr">
+    <img src="https://img.shields.io/badge/thanks.dev-Sponsor-2EBC4F" alt="Sponsor via thanks.dev" />
+  </a>
   <br>
   <b>Platforms:</b> Android | iOS | Windows | Linux | macOS
   <br>


### PR DESCRIPTION
Links the badges to the funding targets already declared in
.github/FUNDING.yml so visitors have a visible path to support
the project from the project landing page.