### PR TITLE
fix: broadcast battlemap HP and token sizes to player view (v12.1.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Dungeon Master Tool v12.1.0
+
+**Release date:** June 2026
+
+### Bug Fixes
+
+- **Battlemap: HP bars now visible in player view** — Fixed an issue where HP bars were not displayed for players even when the DM had "Show HP" enabled. The `showAllHp` flag is now correctly propagated through all broadcast paths (`updateBattleMapSnapshot` and the online patch pipeline).
+- **Battlemap: Token sizes now correct in player view** — Fixed an issue where all tokens appeared the same size in the player view regardless of creature size (Large, Huge, Gargantuan, etc.). Full creature-size multipliers are now computed from each combatant's entity and broadcast to players, instead of only sending manual resize overrides.
+
+---
+
 ## Dungeon Master Tool v12.0.2 — Package Online Sync, Beta Backstop, Dark-Theme Readability (Beta)
 
 **Release date:** June 2026

--- a/flutter_app/lib/application/providers/projection_provider.dart
+++ b/flutter_app/lib/application/providers/projection_provider.dart
@@ -372,6 +372,8 @@ class ProjectionController extends StateNotifier<ProjectionState> {
     final cur = current.snapshot;
 
     // Merge: combat data from `snapshot`, drawing/fog/etc. from `cur`.
+    // showAllHp, hideTokenHud, tokenSizeMultipliers come from the
+    // encounter-derived snapshot so they stay in sync with DM settings.
     final merged = cur.copyWith(
       tokens: snapshot.tokens,
       turnIndex: snapshot.turnIndex,
@@ -381,6 +383,9 @@ class ProjectionController extends StateNotifier<ProjectionState> {
       // Carry the vector scene blob from the encounter so it survives this
       // tokens-only merge (Phase 0 transport — nothing renders it yet).
       sceneVectorJson: snapshot.sceneVectorJson,
+      showAllHp: snapshot.showAllHp,
+      hideTokenHud: snapshot.hideTokenHud,
+      tokenSizeMultipliers: snapshot.tokenSizeMultipliers,
     );
 
     // Local state update — no full push.
@@ -391,13 +396,16 @@ class ProjectionController extends StateNotifier<ProjectionState> {
     ];
     state = state.copyWith(items: newItems);
 
-    // Tokens-only patch to the output — small payload regardless
-    // of how big the fog bitmap is.
+    // Patch to the output — includes HP/HUD flags and size multipliers so
+    // players see correct token sizes and HP bars without a full fog re-upload.
     _pushBattleMapPatch(itemId, {
       'tokens': snapshot.tokens.map((t) => t.toJson()).toList(),
       'turnIndex': snapshot.turnIndex,
       if (snapshot.sceneVectorJson.isNotEmpty)
         'sceneVectorJson': snapshot.sceneVectorJson,
+      'showAllHp': snapshot.showAllHp,
+      'hideTokenHud': snapshot.hideTokenHud,
+      'tokenSizeMultipliers': snapshot.tokenSizeMultipliers,
     });
   }
 

--- a/flutter_app/lib/core/constants.dart
+++ b/flutter_app/lib/core/constants.dart
@@ -5,7 +5,7 @@ const String appName = 'Dungeon Master Tool';
 // from the bundled pubspec version (Android/iOS/desktop) or the web build's
 // info.json, so a `flutter build` automatically reflects the new version
 // without hand-editing this file.
-String appVersion = '12.0.2';
+String appVersion = '12.1.0';
 const String appProcess = 'beta';
 String get appReleaseTag => '$appProcess-v$appVersion';
 const String githubRepo = 'elymsyr/dungeon-master-tool';

--- a/flutter_app/lib/presentation/screens/battle_map/battle_map_notifier.dart
+++ b/flutter_app/lib/presentation/screens/battle_map/battle_map_notifier.dart
@@ -8,15 +8,19 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../application/providers/character_provider.dart';
 import '../../../application/providers/combat_provider.dart';
+import '../../../application/providers/entity_provider.dart';
 import '../../../application/providers/projection_provider.dart';
 import '../../../application/services/asset_ref_resolver.dart';
 import '../../../application/services/map_image_upload.dart';
 import '../../../application/services/pending_write_buffer.dart';
+import '../../../domain/entities/entity.dart';
 import '../../../domain/entities/projection/battle_map_snapshot.dart';
 import '../../../domain/entities/projection/projection_item.dart';
 import '../../../domain/entities/session.dart';
 import '../../../domain/value_objects/asset_ref.dart';
+import '../../../domain/value_objects/creature_size.dart';
 import '../../../domain/value_objects/grid_distance.dart';
 import '../../../domain/value_objects/map_shape.dart';
 import '../../../domain/value_objects/media_kind.dart';
@@ -596,13 +600,43 @@ class BattleMapNotifier extends StateNotifier<BattleMapState> {
       shapeSnaps.add(_toShapeSnapshot(s));
     }
 
+    // Compute full token-size multipliers (auto creature-size + manual
+    // overrides), mirroring BattleMapSnapshotBuilder.build() exactly.
+    // state.tokenSizeMultipliers only holds manual resizes; without this
+    // recomputation, all tokens appear the same size on the player view
+    // after the DM reopens the battle map screen.
+    final encounter = _ref
+        .read(combatProvider)
+        .encounters
+        .where((e) => e.id == encounterId)
+        .firstOrNull;
+    final entityMap = _ref.read(entityProvider);
+    final charEntityMap = <String, Entity>{
+      for (final ch in _ref.read(combatCharactersProvider))
+        ch.entity.id: ch.entity,
+    };
+    final fullMultipliers = <String, double>{};
+    if (encounter != null) {
+      for (final c in encounter.combatants) {
+        final manualMult = encounter.tokenSizeMultipliers[c.id];
+        final entity = c.entityId != null
+            ? (entityMap[c.entityId!] ?? charEntityMap[c.entityId!])
+            : null;
+        final cells = tokenCellSpan(entity, entityMap);
+        fullMultipliers[c.id] = manualMult ??
+            (state.tokenSize > 0
+                ? cells * state.gridSize / state.tokenSize
+                : cells);
+      }
+    }
+
     _ref.read(projectionControllerProvider.notifier).updateBattleMapDrawings(
           itemId: proj.id,
           strokes: strokeSnaps,
           measurements: measurementSnaps,
           shapes: shapeSnaps,
           tokenSize: state.tokenSize,
-          tokenSizeMultipliers: state.tokenSizeMultipliers,
+          tokenSizeMultipliers: fullMultipliers,
           gridVisible: state.gridVisible,
           gridSize: state.gridSize,
           feetPerCell: state.feetPerCell,

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dungeon_master_tool
 description: "D&D Dungeon Master Tool — Schema-driven campaign management for tabletop RPGs."
 publish_to: 'none'
-version: 12.0.2
+version: 12.1.0
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
Two player-view bugs fixed:

1. Token sizes: _pushDrawingsToProjection was sending only manual
   resize overrides instead of full creature-size-driven multipliers.
   Now mirrors BattleMapSnapshotBuilder.build() logic using combatProvider
   + entityProvider + combatCharactersProvider.

2. HP visibility: updateBattleMapSnapshot was not propagating showAllHp,
   hideTokenHud, or tokenSizeMultipliers into the local state merge or
   the broadcast patch. Both copyWith merge and _pushBattleMapPatch now
   include all three fields.

Bump version to 12.1.0 and add release note.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U22KgUfvq3nr41TPz8Kgs3