### PR TITLE
fix: stop soundmap audio on hub exit, bump version to 12.1.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,38 @@
 # Release Notes
 
+## Dungeon Master Tool v12.1.1 — Soundmap Music Stops on Hub Exit (Beta)
+
+**Release date:** June 2026
+**Downloads & source:** [GitHub release](https://github.com/elymsyr/dungeon-master-tool/releases/tag/v12.1.1) · [elymsyr.github.io](https://elymsyr.github.io/)
+
+Patch release. Fixes a single bug: music and ambience playing through the Soundmap kept running after the DM or player returned to the Hub screen. No new features, no migrations.
+
+---
+
+### Bug fixes
+
+- **Soundmap: music and ambience no longer continue after "Back to Hub"** — Selecting "Back to Hub" from inside a world now fully stops all Soundmap playback (music, ambience) before navigating to the Hub. Previously the audio engine kept running in the background, with no way to stop it from the Hub screen.
+
+---
+
+### Upgrade notes
+
+- **App version bump:** `12.1.0` → `12.1.1`.
+- **Local DB:** unchanged. No client migration.
+- **No cloud migrations.**
+
+---
+
+### Known issues
+
+- Carry-over from v12.1.0: feat effect parsing stays conservative; subspecies reclassification on legacy packs is heuristic; smoother large-grid performance, stat-block token previews, and line-of-sight / dynamic vision are still roadmap items; official catalog R2 publish awaits worker deploy + licensing sign-off; full WYSIWYG editors for schemas/templates/packages still in progress; feat-ASI honoring applies only to newly-recorded picks; Tier-4 combat-tracker-dependent effects pending; D7 Drift v12 round-trip test harness pending.
+
+---
+
+*Thanks for playing. Roll well.*
+
+---
+
 ## Dungeon Master Tool v12.1.0
 
 **Release date:** June 2026

--- a/flutter_app/lib/core/constants.dart
+++ b/flutter_app/lib/core/constants.dart
@@ -5,7 +5,7 @@ const String appName = 'Dungeon Master Tool';
 // from the bundled pubspec version (Android/iOS/desktop) or the web build's
 // info.json, so a `flutter build` automatically reflects the new version
 // without hand-editing this file.
-String appVersion = '12.1.0';
+String appVersion = '12.1.1';
 const String appProcess = 'beta';
 String get appReleaseTag => '$appProcess-v$appVersion';
 const String githubRepo = 'elymsyr/dungeon-master-tool';

--- a/flutter_app/lib/presentation/screens/main_screen.dart
+++ b/flutter_app/lib/presentation/screens/main_screen.dart
@@ -221,6 +221,7 @@ class _MainScreenState extends ConsumerState<MainScreen>
     );
     ref.invalidate(campaignListProvider);
     ref.invalidate(campaignInfoListProvider);
+    ref.read(soundpadStateProvider.notifier).stopAll();
     if (mounted) context.go('/hub');
   }
 

--- a/flutter_app/lib/presentation/screens/player/player_main_screen.dart
+++ b/flutter_app/lib/presentation/screens/player/player_main_screen.dart
@@ -11,6 +11,7 @@ import '../../../application/providers/edit_mode_provider.dart';
 import '../../../application/providers/entity_provider.dart';
 import '../../../application/providers/global_loading_provider.dart';
 import '../../../application/providers/locale_provider.dart';
+import '../../../application/providers/soundpad_provider.dart';
 import '../../../application/providers/sync_engine_provider.dart';
 import '../../../application/providers/theme_provider.dart';
 import '../../../application/providers/undo_redo_provider.dart';
@@ -138,6 +139,7 @@ class _PlayerMainScreenState extends ConsumerState<PlayerMainScreen> {
     );
     ref.invalidate(campaignListProvider);
     ref.invalidate(campaignInfoListProvider);
+    ref.read(soundpadStateProvider.notifier).stopAll();
     if (mounted) context.go('/hub');
   }
 

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dungeon_master_tool
 description: "D&D Dungeon Master Tool — Schema-driven campaign management for tabletop RPGs."
 publish_to: 'none'
-version: 12.1.0
+version: 12.1.1
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
Music and ambience kept playing after the DM or player returned to the
Hub via "Back to Hub". Both MainScreen and PlayerMainScreen now call
soundpadStateProvider.notifier.stopAll() before navigating to /hub,
which stops the SoLoud engine and resets provider state atomically.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmUbCo5q7ndsarZ4HamySX